### PR TITLE
Unscore invalid matchpredictions, verify probabilites in edge calc

### DIFF
--- a/vali_utils/scoring_utils.py
+++ b/vali_utils/scoring_utils.py
@@ -15,6 +15,7 @@ from vali_utils import utils
 from common.data import League, MatchPredictionWithMatchData, ProbabilityChoice
 from common.constants import (
     MAX_PREDICTION_DAYS_THRESHOLD,
+    MINIMUM_PREDICTION_PROBABILITY,
     ROLLING_PREDICTION_THRESHOLD_BY_LEAGUE,
     NO_LEAGUE_COMMITMENT_PENALTY
 )
@@ -41,6 +42,10 @@ def calculate_edge(prediction_team: str, prediction_prob: float, actual_team: st
 
     # draws have no edge. temporary
     if prediction_team == "Draw" or winning_closing_odds == losing_closing_odds:
+        reward_punishment = 0
+        
+    # Sanity check to ensure valid probabilities.
+    if prediction_prob < MINIMUM_PREDICTION_PROBABILITY or prediction_prob > 1:
         reward_punishment = 0
     
     edge = consensus_closing_odds - (1 / prediction_prob)


### PR DESCRIPTION
The hypothesis is that there were already previously match predictions which yielded ridiculous probabilities in the database already before the change for (61418b9e6e9532f6d4f301b8e7162fa9a48d8016](https://github.com/sportstensor/sportstensor/commit/61418b9e6e9532f6d4f301b8e7162fa9a48d8016) was merged. This led to some invalid requests making it through before they were rejecting by the previous commit. This hotfix unscores all of these invalid predictions, and modifies the edge_calculation function to rescore them as if they were never there.