### PR TITLE
Api/odds api matches

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -64,18 +64,19 @@ GET_MATCH_QUERY = """
             m.awayTeamName,
             m.sport,
             CASE
-                WHEN m.isComplete = 1 THEN COALESCE(m.homeTeamScore, 0)
-                ELSE m.homeTeamScore 
+                WHEN m.isComplete = 1 THEN COALESCE(moa.homeTeamScore, m.homeTeamScore, 0)
+                ELSE COALESCE(moa.homeTeamScore, m.homeTeamScore)
             END AS homeTeamScore,
             CASE 
-                WHEN m.isComplete = 1 THEN COALESCE(m.awayTeamScore, 0)
-                ELSE m.awayTeamScore 
+                WHEN m.isComplete = 1 THEN COALESCE(moa.awayTeamScore, m.awayTeamScore, 0)
+                ELSE COALESCE(moa.awayTeamScore, m.awayTeamScore)
             END AS awayTeamScore,
             m.matchLeague,
             m.isComplete,
             ml.oddsapiMatchId
         FROM matches m
         LEFT JOIN matches_lookup ml ON m.matchId = ml.matchId
+        LEFT JOIN matches_oddsapi moa ON ml.oddsapiMatchId = moa.oddsapiMatchId
     ) mlo
     LEFT JOIN match_odds mo ON mlo.oddsapiMatchId = mo.oddsapiMatchId AND mo.lastUpdated = (
         SELECT lastUpdated

--- a/api/db.py
+++ b/api/db.py
@@ -566,6 +566,29 @@ def insert_match_oddsapi(match_id, event, sport_type, home_team_score, away_team
         c.close()
         conn.close()
 
+def get_match_oddsapi_by_id(match_id):
+    try:
+        conn = get_db_conn()
+        cursor = conn.cursor(dictionary=True)
+
+        query = """
+            SELECT *
+            FROM matches_oddsapi
+            LEFT JOIN matches_lookup ON matches_oddsapi.oddsapiMatchId = matches_lookup.oddsapiMatchId
+            WHERE matches_lookup.matchId = %s
+        """
+        cursor.execute(query, (match_id,))
+        match_oddsapi = cursor.fetchone()
+
+        return match_oddsapi
+
+    except Exception as e:
+        logging.error("Failed to retrieve match from matches_oddsapi from the MySQL database", exc_info=True)
+        return False
+    finally:
+        cursor.close()
+        conn.close()
+
 def insert_sportsdb_match_lookup(match_id, sportsdb_match_id):
     try:
         conn = get_db_conn()

--- a/api/fetch_matches.py
+++ b/api/fetch_matches.py
@@ -165,7 +165,9 @@ def fetch_and_store_events():
             )
             
             # Only do the cross-check with oddsapi if this isn't a new match
-            final_is_complete = initial_is_complete
+            #final_is_complete = initial_is_complete
+            # If oddsapi says match is not complete, don't mark it as such
+            final_is_complete = 0
             if not new_match:
                 # Get the match data from oddsapi
                 oddsapi_match = db.get_match_oddsapi_by_id(match_id)
@@ -232,11 +234,11 @@ def fetch_and_store_events_oddsapi():
     #end_period = current_utc_time + timedelta(hours=48)
 
     filtered_sports_types = [
-        type for type in ODDSAPI_SPORTS_TYPES if type['league'] in active_leagues
+        sports_type for sports_type in ODDSAPI_SPORTS_TYPES if sports_type['league'] in active_leagues
     ]
 
-    for type in filtered_sports_types:
-        api_url = f"https://api.the-odds-api.com/v4/sports/{type['sport_key']}/scores/"
+    for sports_type in filtered_sports_types:
+        api_url = f"https://api.the-odds-api.com/v4/sports/{sports_type['sport_key']}/scores/"
         params = {
             "apiKey": ODDS_API_KEY,
             "daysFrom": 3,
@@ -246,7 +248,7 @@ def fetch_and_store_events_oddsapi():
             data = response.json()
             all_events.extend(data)
         else:
-            logging.error(f"Failed to fetch events for sport {type['sport_key']}:", response.status_code)
+            logging.error(f"Failed to fetch events for sport {sports_type['sport_key']}:", response.status_code)
             return None
 
     if not all_events:

--- a/api/fetch_matches.py
+++ b/api/fetch_matches.py
@@ -165,9 +165,8 @@ def fetch_and_store_events():
             )
             
             # Only do the cross-check with oddsapi if this isn't a new match
-            #final_is_complete = initial_is_complete
+            final_is_complete = initial_is_complete
             # If oddsapi says match is not complete, don't mark it as such
-            final_is_complete = 0
             if not new_match:
                 # Get the match data from oddsapi
                 oddsapi_match = db.get_match_oddsapi_by_id(match_id)
@@ -175,7 +174,9 @@ def fetch_and_store_events():
                 if oddsapi_match:
                     # Check if both sources agree the match is complete
                     if oddsapi_match.get("isComplete") == 1:
-                        final_is_complete = 1  # If oddsapi says it's complete, let's use it
+                        final_is_complete = 1
+                    elif oddsapi_match.get("isComplete") == 0:
+                        final_is_complete = 0
             
             sport_type = sport_mapping.get(
                 event.get("strSport").upper(), 0

--- a/api/fetch_matches.py
+++ b/api/fetch_matches.py
@@ -10,10 +10,37 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 
-from api.config import NETWORK
+from api.config import NETWORK, ODDS_API_KEY
 
 # Define sport mapping
 sport_mapping = {"SOCCER": 1, "AMERICAN FOOTBALL": 2, "BASEBALL": 3, "BASKETBALL": 4}
+ODDSAPI_SPORTS_TYPES = [
+    {
+        'sport_key': 'baseball_mlb',
+        'sport_id': 3,
+        'league': 'MLB',
+    },
+    {
+        'sport_key': 'americanfootball_nfl',
+        'sport_id': 2,
+        'league': 'NFL',
+    },
+    {
+        'sport_key': 'soccer_usa_mls',
+        'sport_id': 1,
+        'league': 'American Major League Soccer',
+    },
+    {
+        'sport_key': 'soccer_epl',
+        'sport_id': 1,
+        'league': 'English Premier League',
+    },
+    {
+        'sport_key': 'basketball_nba',
+        'sport_id': 4,
+        'league': 'NBA',
+    },
+]
 
 
 def parse_datetime_with_optional_timezone(timestamp):
@@ -156,12 +183,124 @@ def fetch_and_store_events():
     except Exception as e:
         logging.error("Failed inserting events into the MySQL database", exc_info=True)
 
+def fetch_and_store_events_oddsapi():
+    api_endpoints_url = (
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vQJcedkDc0c3rijp6gX9eSiq1QDRpMlbiZMywPc3amzznLyiLSOqc6dfbz5Hd18dqPgQVbvp91NSCSE/pub?gid=1997764475&single=true&output=csv"
+        if NETWORK == "test"
+        else "https://docs.google.com/spreadsheets/d/e/2PACX-1vQJcedkDc0c3rijp6gX9eSiq1QDRpMlbiZMywPc3amzznLyiLSOqc6dfbz5Hd18dqPgQVbvp91NSCSE/pub?gid=0&single=true&output=csv"
+    )
+
+    # get leagues that are active
+    active_leagues = []
+    try:
+        response = requests.get(api_endpoints_url)
+        response.raise_for_status()
+
+        # split the response text into lines
+        lines = response.text.split("\n")
+        # filter the lines to include only those where column C is "Active"
+        active_leagues = [
+            line.split(",")[0].strip()
+            for line in lines[1:]
+            if line.split(",")[5].strip() == "Active"
+        ]
+        logging.info(f"Loaded {len(active_leagues)} active leagues from {api_endpoints_url}")
+
+    except Exception as e:
+        logging.error(f"Error loading active leagues from URL {api_endpoints_url}: {e}")
+        return
+
+    logging.info("Fetching data from The Odds Api")
+    all_events = []
+
+    current_utc_time = datetime.now(timezone.utc)
+    #start_period = current_utc_time - timedelta(days=10)
+    #end_period = current_utc_time + timedelta(hours=48)
+
+    filtered_sports_types = [
+        type for type in ODDSAPI_SPORTS_TYPES if type['league'] in active_leagues
+    ]
+
+    for type in filtered_sports_types:
+        api_url = f"https://api.the-odds-api.com/v4/sports/{type['sport_key']}/scores/"
+        params = {
+            "apiKey": ODDS_API_KEY,
+        }
+        response = requests.get(api_url, params=params)
+        if response.status_code == 200:
+            data = response.json()
+            all_events.extend(data)
+        else:
+            logging.error(f"Failed to fetch events for sport {type['sport_key']}:", response.status_code)
+            return None
+
+    if not all_events:
+        logging.info("No events data found in the Odds Api responses")
+        return
+
+    current_utc_time = current_utc_time.strftime("%Y-%m-%d %H:%M:%S")
+
+    try:
+        for event in all_events:
+            event_id = event.get("id")
+
+            """ No need for lookup table right now.
+            # Query the lookup table
+            match_id = db.query_sportsdb_match_lookup(event_id)
+            new_match = False
+            if match_id is None:
+                match_id = create_match_id()
+                new_match = True
+            """
+
+            status = event.get("completed")
+            is_complete = 0
+            if status:
+                is_complete = 1
+            
+            sport_key = event.get("sport_key", "").lower()
+            sport_type = ODDSAPI_SPORTS_TYPES.get(
+                sport_key, {}).get('sport_id', 0)
+            if not sport_type:
+                # If sport_type is not found in the mapping, default to 0
+                sport_type = 0
+            
+            if isinstance(event.get("commence_time"), (int, float)) or event.get("commence_time").isdigit():
+                # Handle Unix timestamp (seconds since epoch)
+                matchTimestamp = datetime.fromtimestamp(float(event.get("commence_time")), tz=timezone.utc)
+                matchTimestampStr = matchTimestamp.strftime("%Y-%m-%d %H:%M:%S")
+                event.update({"commence_time": matchTimestampStr})
+
+            home_team_score, away_team_score = None, None
+            if event.get("scores") is not None and len(event.get("scores")) > 0:
+                for score in event.get("scores"):
+                    if score.get("name") is not None and score.get("name") == event.get("home_team"):
+                        home_team_score = score.get("score")
+                    if score.get("name") is not None and score.get("name") == event.get("away_team"):
+                        away_team_score = score.get("score")
+
+            dbresult = db.insert_match_oddsapi(
+                event_id, event, sport_type, home_team_score, away_team_score, is_complete, current_utc_time
+            )
+            """ No need for lookup table right now.
+            if dbresult and new_match:
+                dbresult2 = db.insert_sportsdb_match_lookup(match_id, event_id)
+                if dbresult2:
+                    logging.info(f"Inserted matchId {match_id} and sportsdbMatchId {event_id} lookup into the database")
+            """
+
+    except Exception as e:
+        logging.error("Failed inserting Odds Api events into the MySQL database", exc_info=True)
+
 if __name__ == "__main__":
     # Schedule the function to run every 10 minutes
     schedule.every(10).minutes.do(fetch_and_store_events)
+    schedule.every(10).minutes.do(fetch_and_store_events_oddsapi)
 
     # Initial fetch and store to ensure setup is correct
     fetch_and_store_events()
+    # Initial fetch and store for Odds API
+    fetch_and_store_events_oddsapi()
 
     # Run the scheduler in an infinite loop
     while True:

--- a/api/fetch_matches.py
+++ b/api/fetch_matches.py
@@ -239,7 +239,7 @@ def fetch_and_store_events_oddsapi():
         api_url = f"https://api.the-odds-api.com/v4/sports/{type['sport_key']}/scores/"
         params = {
             "apiKey": ODDS_API_KEY,
-            "daysFrom": 1,
+            "daysFrom": 3,
         }
         response = requests.get(api_url, params=params)
         if response.status_code == 200:

--- a/api/fetch_matches.py
+++ b/api/fetch_matches.py
@@ -259,11 +259,12 @@ def fetch_and_store_events_oddsapi():
                 is_complete = 1
             
             sport_key = event.get("sport_key", "").lower()
-            sport_type = ODDSAPI_SPORTS_TYPES.get(
-                sport_key, {}).get('sport_id', 0)
-            if not sport_type:
-                # If sport_type is not found in the mapping, default to 0
-                sport_type = 0
+            
+            sport_type = 0
+            for sport in filtered_sports_types:
+                if sport['sport_key'] == sport_key:
+                    sport_type = sport['sport_id']
+                    break
             
             if isinstance(event.get("commence_time"), (int, float)) or event.get("commence_time").isdigit():
                 # Handle Unix timestamp (seconds since epoch)

--- a/api/fetch_matches.py
+++ b/api/fetch_matches.py
@@ -166,27 +166,14 @@ def fetch_and_store_events():
             
             # Only do the cross-check with oddsapi if this isn't a new match
             final_is_complete = initial_is_complete
-            if not new_match and initial_is_complete == 1:
+            if not new_match:
                 # Get the match data from oddsapi
                 oddsapi_match = db.get_match_oddsapi_by_id(match_id)
                 
                 if oddsapi_match:
                     # Check if both sources agree the match is complete
-                    if oddsapi_match.get("isComplete") != 1:
-                        final_is_complete = 0  # If oddsapi doesn't think it's complete, don't mark it complete
-                    else:
-                        # Check if scores match between the two sources
-                        sportsdb_home_score = event.get("intHomeScore")
-                        sportsdb_away_score = event.get("intAwayScore")
-                        oddsapi_home_score = oddsapi_match.get("homeTeamScore")
-                        oddsapi_away_score = oddsapi_match.get("awayTeamScore")
-                        
-                        # If either source has NULL scores or scores don't match, don't mark as complete
-                        if (sportsdb_home_score is None or oddsapi_home_score is None or
-                            sportsdb_away_score is None or oddsapi_away_score is None or
-                            int(sportsdb_home_score) != int(oddsapi_home_score) or
-                            int(sportsdb_away_score) != int(oddsapi_away_score)):
-                            final_is_complete = 0
+                    if oddsapi_match.get("isComplete") == 1:
+                        final_is_complete = 1  # If oddsapi says it's complete, let's use it
             
             sport_type = sport_mapping.get(
                 event.get("strSport").upper(), 0


### PR DESCRIPTION
Adds a new `matches_oddsapi` table that will collect/update the matches from our Odds Api provider. These event ids are already tied to our `odds` and `matches_lookup` tables and system.

We will now allow oddsapi events marked as `completed` to override that status for our `/matches` endpoint.
Also, the `/matches` endpoint will use the scores from the oddsapi events if they are available and fallback to sportsdb data.